### PR TITLE
[ Bug fix ] fix css and js path //

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ VkSwiper::enqueue_swiper();
 ---
 
 ## Change log
+
+= 0.3.2 =
+* [ Bug fix ] fix css and js path //

--- a/src/VkSwiper.php
+++ b/src/VkSwiper.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-swiper
  * @license GPL-2.0+
  *
- * @version 0.3.1
+ * @version 0.3.2
  */
 
 namespace VektorInc\VK_Swiper;
@@ -52,8 +52,8 @@ class VkSwiper {
 	 */
 	public static function register_swiper() {
 		$current_url  = self::get_directory_uri( dirname( __FILE__ ) );
-		wp_register_style( 'vk-swiper-style', $current_url . '/assets/css/swiper-bundle.min.css', array(), SWIPER_VERSION );
-		wp_register_script( 'vk-swiper-script', $current_url . '/assets/js/swiper-bundle.min.js', array(), SWIPER_VERSION, true );
+		wp_register_style( 'vk-swiper-style', $current_url . 'assets/css/swiper-bundle.min.css', array(), SWIPER_VERSION );
+		wp_register_script( 'vk-swiper-script', $current_url . 'assets/js/swiper-bundle.min.js', array(), SWIPER_VERSION, true );
 	}
 
 	/**


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

大橋君からの連絡

js と css のパスが途中で // になる。
通常問題ないが Shifter など特定環境では読み込みに失敗する
```
<link rel='stylesheet' id='vk-swiper-style-css' href='http://localhost:8888/wp-content/plugins/vk-blocks-pro/vendor/vektor-inc/vk-swiper/src//assets/css/swiper-bundle.min.css?ver=9.3.2' media='all' />
<script src='http://localhost:8888/wp-content/plugins/vk-blocks-pro/vendor/vektor-inc/vk-swiper/src//assets/js/swiper-bundle.min.js?ver=9.3.2' id='vk-swiper-script-js'></script>
```