### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,11 +4,10 @@ on:
     pull_request:
         branches:
             - main
-    push:
-        branches:
-            - main
+        types: [opened, reopened, labeled, synchronize]
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストの実行タイミングを見直します。push での自動実行を廃止し、PR は `run-ci` ラベルが付いたときのみ実行するようにします。

## 変更内容
- `.github/workflows/phpunit.yml`
  - `on.push`（main への push）トリガーを削除
  - `on.pull_request` に `types: [opened, reopened, labeled, synchronize]` を追加
  - `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加

## 確認手順
1. ラベル無しの PR ではワークフローが起動しないこと
2. `run-ci` ラベルを付与すると起動すること
3. push（main 等）では起動しないこと
4. リリース時（該当する場合）は従来どおりであること

CI 設定のみの変更であり、プラグインの動作には影響しません。

関連: vektor-inc/multi-repo-tasks#24
